### PR TITLE
Add confirmation to users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :confirmable
 
   validates :username, presence: true, uniqueness: true
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -157,7 +157,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]

--- a/db/migrate/20231012013933_add_confirmable_to_devise.rb
+++ b/db/migrate/20231012013933_add_confirmable_to_devise.rb
@@ -1,0 +1,21 @@
+class AddConfirmableToDevise < ActiveRecord::Migration[7.0]
+  # Note: You can't use change, as User.update_all will fail in the down migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    # add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :users, :confirmation_token, unique: true
+    # User.reset_column_information # Need for some types of updates, but not for update_all.
+    # To avoid a short time window between running the migration and updating all existing
+    # users as confirmed, do the following
+    User.update_all confirmed_at: DateTime.now
+    # All existing user accounts should be able to log in after this.
+  end
+
+  def down
+    remove_index :users, :confirmation_token
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+    # remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_09_172753) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_12_013933) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_09_172753) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username", null: false
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -7,10 +7,11 @@ describe 'post', type: :feature do
   before :each do
     @post = FactoryBot.build(:post)
     @user = FactoryBot.create(:user)
+    @user.confirm
     FactoryBot.create(:label)
     visit '/users/sign_in'
     within('#new_user') do
-      fill_in 'Email', with: User.last.email
+      fill_in 'Email', with: @user.email
       fill_in 'Password', with: 'test1234'
     end
     click_button 'Log in'
@@ -71,11 +72,9 @@ describe 'post', type: :feature do
   end
 
   context 'delete post' do
-    before :each do
-      @post = FactoryBot.create(:post, :with_user)
-    end
-
     it 'successfully' do
+      @post.user = @user
+      @post.save!
       visit posts_path(@post)
       click_on 'delete'
       expect(page).to have_content 'Post was successfully destroyed'
@@ -83,11 +82,9 @@ describe 'post', type: :feature do
   end
 
   context 'view post' do
-    before :each do
-      @post = FactoryBot.create(:post, :with_user)
-    end
-
     it 'successfully' do
+      @post.user = @user
+      @post.save!
       visit post_path(@post)
       expect(page).to have_content @post.title
       expect(page).to have_content @post.content

--- a/spec/features/signin_spec.rb
+++ b/spec/features/signin_spec.rb
@@ -1,24 +1,35 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require 'rails_helper'
 
-describe "Sign in", type: :feature do
+describe 'Sign in', type: :feature do
   before :each do
-    FactoryBot.create(:user)
+    @user = FactoryBot.create(:user)
     visit '/users/sign_in'
   end
 
-  it "signs me in" do
-    within("#new_user") do
-      fill_in 'Email', with: User.last.email
+  it 'signs me in with a not confirmed account' do
+    within('#new_user') do
+      fill_in 'Email', with: @user.email
       fill_in 'Password', with: 'test1234'
     end
     click_button 'Log in'
+    expect(page).to have_content 'You have to confirm your email address before continuing.'
+  end
+
+  it 'signs me in' do
+    within('#new_user') do
+      fill_in 'Email', with: @user.email
+      fill_in 'Password', with: 'test1234'
+    end
+    @user.confirm
+    click_button 'Log in'
+
     expect(page).to have_content 'Signed in successfully'
   end
 
-  it "signs me in with empty values" do
-    within("#new_user") do
+  it 'signs me in with empty values' do
+    within('#new_user') do
       fill_in 'Email', with: ''
       fill_in 'Password', with: ''
     end

--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -17,7 +17,7 @@ describe 'Sign up', type: :feature do
       fill_in 'Confirm Password', with: @user.password
     end
     click_button 'Sign up'
-    expect(page).to have_content ' Welcome! You have signed up successfully'
+    expect(page).to have_content 'A message with a confirmation link has been sent to your email address. Please follow the link to activate your account.'
   end
 
   it 'signs me in with empty values' do

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -5,6 +5,7 @@ module ControllerMacros
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
       user = FactoryBot.create(:user)
+      user.confirm
       sign_in user
     end
   end


### PR DESCRIPTION
## Quick Info
We need to add a verification step to make sure every user has a real email account and avoid spam users.

## What does this change?
Adds a double validation for new users to confirm their account before login. 

## How do you manually test this?
- Pull branch
- Run the migration
- If you have a current user logs out
- Try to login again
- Or create a new user and try login to the page
If you need to confirm a user account from terminal use: `User.find_by(id: 1).confirm`