### PR TITLE
improve UI in update account view

### DIFF
--- a/app/assets/stylesheets/shared/_sessions.scss
+++ b/app/assets/stylesheets/shared/_sessions.scss
@@ -8,3 +8,35 @@
 .adapt-links p {
   margin: 1rem 0 0;
 }
+
+.form-container > form {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+
+.update-buttton {
+  display: grid;
+}
+
+.unhappy-container {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+#dropdown1 {
+  left: 725px !important;
+  top: 64px !important;
+}
+
+.cancel-account-button {
+  align-items: center;
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.cancel-account-button i {
+  margin-right: .5rem;
+}

--- a/app/assets/stylesheets/shared/_sessions.scss
+++ b/app/assets/stylesheets/shared/_sessions.scss
@@ -27,7 +27,6 @@
 }
 
 #dropdown1 {
-  left: 725px !important;
   top: 64px !important;
 }
 

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -21,8 +21,9 @@
             - if devise_mapping.confirmable? && resource.pending_reconfirmation?
               %div
                 Currently waiting confirmation for: #{resource.unconfirmed_email}
-        .field.center
-          = f.label "change password (#{@minimum_password_length if @minimum_password_length } characters minimum )"
+        .field
+          .center
+            = f.label "change password (#{@minimum_password_length if @minimum_password_length } characters minimum )"
           .input-field.col.s12
             %i.material-icons.prefix lock_outline
             = f.password_field :password, autocomplete: "new-password", placeholder: "(leave blank if you don't want to change it)"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,49 +1,48 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource,
-           as: resource_name,
-           url: registration_path(resource_name),
-           html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :username
-    %br/
-    = f.text_field :username, autofocus: true, autocomplete: "username"
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email,
-                    autofocus: true,
-                    autocomplete: "email",
-                    readonly: true
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p Unhappy?
-= button_to 'Cancel my account',
-            registration_path(resource_name),
-            data: { confirm: 'Are you sure?' },
-            method: :delete
-= link_to "Back", :back
+%h4.center Edit #{resource_name.to_s.humanize}
+.form-container
+  = form_for(resource,
+            as: resource_name,
+            url: registration_path(resource_name),
+            html: { method: :put }) do |f|
+    .session-form
+      .col.s12.z-depth-6.card-panel
+        .field
+          .input-field.col.s12
+            = render "devise/shared/error_messages", resource: resource
+            %i.material-icons.prefix person
+            = f.text_field :username, autofocus: true, autocomplete: "username"
+        .field
+          .input-field.col.s12
+            %i.material-icons.prefix mail_outline
+            = f.email_field :email,
+                            autofocus: true,
+                            autocomplete: "email",
+                            readonly: true
+            - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+              %div
+                Currently waiting confirmation for: #{resource.unconfirmed_email}
+        .field.center
+          = f.label "change password (#{@minimum_password_length if @minimum_password_length } characters minimum )"
+          .input-field.col.s12
+            %i.material-icons.prefix lock_outline
+            = f.password_field :password, autocomplete: "new-password", placeholder: "(leave blank if you don't want to change it)"
+        .field
+          .input-field.col.s-12
+            %i.material-icons.prefix lock_outline
+            = f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "Password Confirmation"
+        .field
+          .input-field.col.s-12
+            %i.material-icons.prefix verified_user
+            = f.password_field :current_password, autocomplete: "current-password", placeholder:  "Current password to confirm your changes"
+
+        .actions.update-buttton
+          = f.submit "Update", class: "main-btn btn waves-effect waves-light col s12"
+.unhappy-container
+  %p Unhappy with TIL? 😢 
+  = button_to registration_path(resource_name),
+            method: :delete,
+            class: "btn red cancel-account-button" do
+    %i.material-icons cancel
+    Cancel my account
+
+  = link_to "Back", :back


### PR DESCRIPTION
## Quick Info
- Configure edit profile view.

## What does this change?
- Matching styles of updated account forms with the other ones of our app.

## Why are you changing that?
- Because the styles of this view persistent with the devise.

## How do you manually test this?
- Access to update account through the nav bar

## Screenshots (if apply)
- desktop
![image](https://github.com/OswaldoPineda/Today_I_learned/assets/50384228/84a2166c-14d6-4b12-8d7e-6ca05a86589f)
- mobile
![image](https://github.com/OswaldoPineda/Today_I_learned/assets/50384228/0af66f3c-ae06-4e03-bc60-ee4609b0bfdb)

