### PR TITLE
Fix break labels and titles

### DIFF
--- a/app/assets/stylesheets/general/_general.scss
+++ b/app/assets/stylesheets/general/_general.scss
@@ -62,6 +62,7 @@ pre {
 a.badge.badge-main {
   background: $secondary-color;
   border-radius: 8px;
+  text-wrap: nowrap;
   color: $white !important;
   padding: 5px;
 }

--- a/app/assets/stylesheets/posts/_post.scss
+++ b/app/assets/stylesheets/posts/_post.scss
@@ -68,6 +68,10 @@
     justify-content: space-between;
     align-items: center;
    }
+
+   .labels {
+    margin-left: 8px;
+   }
 }
 
 .new-post-title {
@@ -83,6 +87,7 @@
 .card-title {
   color: $black;
   text-transform: capitalize;
+  overflow: auto;
 }
 
 .show-post-container {

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -46,7 +46,7 @@ class PostsController < ApplicationController
   def update
     @post.update_label(params[:post][:label_name])
 
-    if @post.update(title: params[:post][:title], content: params[:post][:content])
+    if @post.errors.empty? && @post.update(title: params[:post][:title], content: params[:post][:content])
       redirect_to_post_with_success('Post was successfully updated.')
     else
       @labels = Label.all
@@ -92,9 +92,9 @@ class PostsController < ApplicationController
   end
 
   def authorize_user
-    unless current_user == @post.user
-      flash[:alert] = "You are not authorized to perform this action."
-      redirect_to posts_path
-    end
+    return if current_user == @post.user
+
+    flash[:alert] = 'You are not authorized to perform this action.'
+    redirect_to posts_path
   end
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -3,7 +3,7 @@
 # Represents a label associated with posts.
 # Labels can be used to categorize and organize posts
 class Label < ApplicationRecord
-  validates :name, presence: true
+  validates :name, length: { minimum: 1, maximum: 15 }, presence: true
   has_and_belongs_to_many :posts
 
   class << self

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -20,24 +20,14 @@ class Post < ApplicationRecord
   end
 
   def update_label(name)
-    label = find_or_create_label(name)
-    self.labels = [label].compact
-  end
+    return unless name
 
-  private
+    label = Label.find_by_variants(name)
 
-  def create_new_label(name)
-    Label.create(name: name.titleize).tap { |new_label| labels << new_label }
-  end
-
-  def find_or_create_label(name)
-    return Label.find_by_variants(name) if label_exists?(name)
-    return nil if name.blank?
-
-    create_new_label(name)
-  end
-
-  def label_exists?(name)
-    Label.find_by_variants(name).present?
+    begin
+      self.labels = [label || Label.create!(name: name.titleize)]
+    rescue ActiveRecord::RecordInvalid
+      errors.add(:label, 'is invalid')
+    end
   end
 end


### PR DESCRIPTION
## Quick Info
This prevents breaking the HTML content when a user adds a long title of one word like:
`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`

and also prevents long labels adding a limit of 15 characters on create and edit.

## Why are you changing that?
We identify some titles breaking the page.

## How do you manually test this?
- Create posts with long titles.
- Update post labels.

## Screenshots (if apply)
Long title of one word with overflow auto
![image](https://github.com/OswaldoPineda/Today_I_learned/assets/26700359/8979e553-ee3c-4729-adbc-a0b1dad3abf7)

Long title with more than one word with overflow auto
![image](https://github.com/OswaldoPineda/Today_I_learned/assets/26700359/77d14dc9-b63d-4827-bc83-02a88bddce7d)