### PR TITLE
fix ausent margin left in li from trix styles

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -58,3 +58,7 @@
     min-height: 12rem
   }
 }
+
+.trix-content li { 
+  margin-left: 1.5em;
+}


### PR DESCRIPTION
## Quick Info
 - These changes add a minimal margin left on trix numeric lists

## before
![image](https://github.com/OswaldoPineda/Today_I_learned/assets/50384228/7306da86-613c-4297-b975-26ca62c1249f)

## after
![image](https://github.com/OswaldoPineda/Today_I_learned/assets/50384228/62512757-7d6c-4fba-80c3-346c7dc76272)
