### PR TITLE
Handle Unlabeled Posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,7 +9,7 @@ class Post < ApplicationRecord
   has_rich_text :content
 
   def add_labels(name)
-    return unless name
+    name ||= 'Unlabeled'
 
     label = Label.find_by_variants(name)
     labels << (label || Label.create(name: name.titleize))

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,8 @@ labels = [
   'Typescript',
   'Helpers',
   'Sass',
-  'Shell'
+  'Shell',
+  'Unlabeled'
 ]
 
 labels.each do |label|


### PR DESCRIPTION
## Quick Info
This enhancement avoids publishing posts without a proper label, in case a user adds a post without a label, it will be marked as unlabeled to add some sort of search by label soon.

## What does this change?
Mark as unlabeled those post without label

## Why are you changing that?
To avoid post without a proper label

## How do you manually test this?
publish a new post without label, and it should be published with a 'unlabeled' label

## Screenshots (if apply)
<img width="471" alt="image" src="https://github.com/OswaldoPineda/Today_I_learned/assets/22619011/b4914d09-08cb-476f-b9da-2f9284162783">

